### PR TITLE
Switch to repo2 instead of repo1 (issue #79)

### DIFF
--- a/buildScripts/ivysettings.xml
+++ b/buildScripts/ivysettings.xml
@@ -6,7 +6,7 @@
 			<filesystem name="projectLocalRepo">
 				<ivy pattern="${ivy.settings.dir}/ivy-repo/[organization]-[module]-[revision].xml" />
 			</filesystem>
-			<ibiblio name="maven-repo2" m2compatible="true" root="http://repo1.maven.org/maven2/" />
+			<ibiblio name="maven-repo2" m2compatible="true" root="http://repo2.maven.org/maven2/" />
 		</chain>
 	</resolvers>
 	<settings defaultResolver="projectRepos" />


### PR DESCRIPTION
Repo1 seems to have some misconfiguration on
org.eclipse.core#org.eclipse.core.runtime;3.6.0.v20100505 and
de.java2html#java2html;5.0
